### PR TITLE
Counter replaced by KeepersCounter. Improve error handling for deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Set your `ETH_RPC_URL` or `ALCHEMY_API_KEY` in your `.env` file, then run one of
 Counters (Keeper Compatible Contract):
 
 ```bash
-make deploy CONTRACT=Counter
+make deploy CONTRACT=KeepersCounter
 ```
 
 Price Feed:
@@ -147,7 +147,7 @@ ETHERSCAN_API_KEY=<api-key> dapp verify-contract <contract_directory>/<contract>
 For example:
 
 ```
-ETHERSCAN_API_KEY=123456765 dapp verify-contract ./src/Counter.sol:Counter 0x23456534212536435424
+ETHERSCAN_API_KEY=123456765 dapp verify-contract ./src/KeepersCounter.sol:KeepersCounter 0x23456534212536435424
 ```
 
 Check out the [dapp documentation](https://github.com/dapphub/dapptools/tree/master/src/dapp#dapp-verify-contract) to see how
@@ -212,7 +212,7 @@ As you can see... it would be great to have these scripted in our `scripts` fold
 # TODO
 
 [x] Enable network & contract choice from the command line
-ie: make deploy-rinkeby contract=counter
+ie: make deploy-rinkeby contract=KeepersCounter
 
 [x] Add mockOracle for any API calls
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -36,13 +36,13 @@ fi
 
 # ensure ETH_FROM is set and give a meaningful error message
 if [[ -z ${ETH_FROM} ]]; then
-	echo "ETH_FROM not found, please set it and re-run the last command."
+	echo "ETH_FROM not found, please set it and re-run the last command." >&2
 	exit 1
 fi
 
 # Make sure address is checksummed
 if [ "$ETH_FROM" != "$(seth --to-checksum-address "$ETH_FROM")" ]; then
-	echo "ETH_FROM not checksummed, please format it with 'seth --to-checksum-address <address>'"
+	echo "ETH_FROM not checksummed, please format it with 'seth --to-checksum-address <address>'" >&2
 	exit 1
 fi
 
@@ -59,28 +59,62 @@ deploy() {
 	NAME=$1
 	ARGS=${@:2}
 
+	if [[ -z "${NAME}" ]]; then
+		echo "ERROR. File name not provided" >&2
+		exit 1
+	fi
+
 	# find file path
 	CONTRACT_PATH=$(find ./src -name $NAME.sol)
 	CONTRACT_PATH=${CONTRACT_PATH:2}
+	if [[ -z "${CONTRACT_PATH}" ]]; then
+		echo "ERROR. File \"${NAME}\" does not exist" >&2
+		exit 1
+	fi
 
 	# select the filename and the contract in it
 	PATTERN=".contracts[\"$CONTRACT_PATH\"].$NAME"
 
 	# Compile / Build
 	dapp build
+	if [[ $? -ne 0 ]]; then
+		echo "ERROR. dapp build failed" >&2
+		exit 1
+	fi
 
 	# get the constructor's signature
-	ABI=$(jq -r "$PATTERN.abi" out/dapp.sol.json)
+	ABI=$(jq -r "$PATTERN.abi // empty" out/dapp.sol.json)
+	if [[ $? -ne 0 ]] || [[ -z "${ABI}" ]]; then
+		echo "ERROR. Unable to get the contract ABI" >&2
+		exit 1
+	fi
+
 	SIG=$(echo "$ABI" | seth --abi-constructor)
+	if [[ $? -ne 0 ]] || [[ -z "${SIG}" ]]; then
+		echo "ERROR. Unable to get the constructor signature" >&2
+		exit 1
+	fi
 
 	# get the bytecode from the compiled file
 	BYTECODE=0x$(jq -r "$PATTERN.evm.bytecode.object" out/dapp.sol.json)
+	if [[ $? -ne 0 ]]; then
+		echo "ERROR. Unable to get the bytecode from the compiled file" >&2
+		exit 1
+	fi
 
 	# estimate gas
 	GAS=$(seth estimate --create "$BYTECODE" "$SIG" $ARGS --rpc-url "$ETH_RPC_URL")
+	if [[ $? -ne 0 ]]; then
+		echo "ERROR. Unable to estimate gas" >&2
+		exit 1
+	fi
 
 	# deploy
 	ADDRESS=$(dapp create "$NAME" $ARGS -- --gas "$GAS" --rpc-url "$ETH_RPC_URL")
+	if [[ $? -ne 0 ]]; then
+		echo "ERROR. Unable to deploy app" >&2
+		exit 1
+	fi
 
 	# save the addrs to the json
 	# TODO: It'd be nice if we could evolve this into a minimal versioning system
@@ -104,17 +138,40 @@ saveContract() {
 estimate_gas() {
 	NAME=$1
 	ARGS=${@:2}
+
+	if [[ -z "${NAME}" ]]; then
+		echo "ERROR. File name not provided" >&2
+		exit 1
+	fi
+
 	# select the filename and the contract in it
 	PATTERN=".contracts[\"src/$NAME.sol\"].$NAME"
 
 	# get the constructor's signature
-	ABI=$(jq -r "$PATTERN.abi" out/dapp.sol.json)
+	ABI=$(jq -r "$PATTERN.abi // empty" out/dapp.sol.json)
+	if [[ $? -ne 0 ]] || [[ -z "${ABI}" ]]; then
+		echo "ERROR. Unable to get the contract ABI" >&2
+		exit 1
+	fi
+
 	SIG=$(echo "$ABI" | seth --abi-constructor)
+	if [[ $? -ne 0 ]] || [[ -z "${SIG}" ]]; then
+		echo "ERROR. Unable to get the constructor signature" >&2
+		exit 1
+	fi
 
 	# get the bytecode from the compiled file
 	BYTECODE=0x$(jq -r "$PATTERN.evm.bytecode.object" out/dapp.sol.json)
+	if [[ $? -ne 0 ]]; then
+		echo "ERROR. Unable to get the bytecode from the compiled file" >&2
+		exit 1
+	fi
 	# estimate gas
 	GAS=$(seth estimate --create "$BYTECODE" "$SIG" $ARGS --rpc-url "$ETH_RPC_URL")
+	if [[ $? -ne 0 ]]; then
+		echo "ERROR. Unable to estimate gas" >&2
+		exit 1
+	fi
 
 	TXPRICE_RESPONSE=$(curl -sL https://api.txprice.com/v1)
 	response=$(jq '.code' <<<"$TXPRICE_RESPONSE")

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -10,7 +10,7 @@ set -eo pipefail
 
 # Deploy 
 # Contract will be counter unless overriden on the command line
-: ${CONTRACT:=Counter}
+: ${CONTRACT:=KeepersCounter}
 echo "Deploying $CONTRACT to $NETWORK with arguments: $arguments"
 Addr=$(deploy $CONTRACT $arguments)
 log "$CONTRACT deployed at:" $Addr

--- a/scripts/helper-config.sh
+++ b/scripts/helper-config.sh
@@ -39,7 +39,7 @@ then
     subId=1
 fi
 
-if [ "$CONTRACT" = "Counter" ]
+if [ "$CONTRACT" = "KeepersCounter" ]
 then 
     arguments=$interval
 elif [ "$CONTRACT" = "PriceFeedConsumer" ]


### PR DESCRIPTION
Initially faced issues when running the  command:

`make deploy-rinkeby CONTRACT=Counter`

After investigations, I realized that `Counter.sol` doesn't exist, the correct name being `KeepersCounter.sol`. Hence the purpose of this PR is :

- Replace all occurrences of `Counter` with `KeepersCounter`
- Enhance error handling of `deploy` step in `common.sh` 